### PR TITLE
Unreverts removal of the nice page switching buttons

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,7 +1,7 @@
 [[source]]
-url = 'https://pypi.python.org/simple'
+url = "https://pypi.python.org/simple"
 verify_ssl = true
-name = 'pypi'
+name = "pypi"
 
 [packages]
 streamlit = "*"
@@ -12,6 +12,7 @@ geopandas = "*"
 streamlit-folium = "*"
 requests = "*"
 branca = "*"
+streamlit-extras = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1d609f1093d68eef65bae8c580a96ec3a416b0035d03044068c6786899fd60be"
+            "sha256": "229b7a065414ad18e1808dc7fd600d7018d0e322edc2e6e258337b9b10684227"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1225,6 +1225,7 @@
                 "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
                 "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
             ],
+            "markers": "python_version < '3.11'",
             "version": "==4.7.1"
         },
         "tzdata": {
@@ -1232,6 +1233,7 @@
                 "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
                 "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2023.3"
         },
         "tzlocal": {
@@ -1293,6 +1295,7 @@
                 "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
                 "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"
             ],
+            "markers": "python_version < '3.10'",
             "version": "==3.15.0"
         }
     },

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This project is staged at [https://sdwa-eew.streamlit.app/](https://sdwa-eew.str
 # Instructions for development
 This app is rendered in Streamlit. To run locally:
 
-1. Install project requirements with `pipenv install`
+1. Install project requirements with `pipenv install`. You may also need to run `pipenv shell`.
 2. Run this app with `streamlit run Welcome.py`

--- a/Welcome.py
+++ b/Welcome.py
@@ -3,6 +3,7 @@
 #https://docs.streamlit.io/library/get-started/create-an-app
 
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
 
 st.set_page_config(layout="wide")
 st.markdown('![EEW logo](https://github.com/edgi-govdata-archiving/EEW-Image-Assets/blob/main/Jupyter%20instructions/eew.jpg?raw=true) ![EDGI logo](https://github.com/edgi-govdata-archiving/EEW-Image-Assets/blob/main/Jupyter%20instructions/edgi.png?raw=true)')
@@ -31,10 +32,9 @@ You can explore imporant questions about SDWA in New Jersey on this website, suc
 * What kinds of pollutants are permitted to be released in the watershed?
 """)
 
-st.markdown(f'''
-<a href="/Statewide_Overview"><button>Get started!</button></a>
-''',
-unsafe_allow_html=True)
+next = st.button("Get Started! >")
+if next:
+    switch_page("statewide overview")
 
 st.markdown("""## How to Use This Website
 (These instructions will be repeated on each page)

--- a/pages/1_🌍_Statewide_Overview.py
+++ b/pages/1_🌍_Statewide_Overview.py
@@ -4,6 +4,7 @@
 import pandas as pd
 import urllib.parse
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
 from streamlit_folium import st_folium
 import geopandas
 import folium
@@ -14,10 +15,10 @@ import requests, zipfile, io
 
 st.set_page_config(layout="wide")
 #st.markdown('![EEW logo](https://github.com/edgi-govdata-archiving/EEW-Image-Assets/blob/main/Jupyter%20instructions/eew.jpg?raw=true) ![EDGI logo](https://github.com/edgi-govdata-archiving/EEW-Image-Assets/blob/main/Jupyter%20instructions/edgi.png?raw=true)')
-st.markdown(f'''
-<a href="/"><button>Previous: Welcome</button></a>
-''',
-unsafe_allow_html=True)
+
+previous = st.button("Previous: Welcome")
+if previous:
+    switch_page("welcome")
 
 st.markdown("""
 # What are the Public Water Systems of New Jersey?
@@ -114,7 +115,6 @@ with c2:
   st.dataframe(st.session_state["sdwa"].groupby(by=p)[[p]].count())
   st.bar_chart(st.session_state["sdwa"].groupby(by=p)[[p]].count().rename(columns={p:"COUNT"}))
 
-st.markdown(f'''
-<a href="/SDWA_Violations"><button>Next: SDWA Violations</button></a>
-''',
-unsafe_allow_html=True)
+next = st.button("Next: Safe Drinking Water Act Violations")
+if next:
+    switch_page("sdwa violations")

--- a/pages/2_💧_SDWA_Violations.py
+++ b/pages/2_💧_SDWA_Violations.py
@@ -4,12 +4,18 @@
 import pandas as pd
 import urllib.parse
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
 from streamlit_folium import st_folium
 import geopandas
 import folium
 from folium.plugins import Draw
 
 st.set_page_config(layout="wide")
+
+previous = st.button("Previous: Statewide Overview")
+if previous:
+    switch_page("statewide overview")
+
 st.markdown(""" # Search for Public Water Systems and Find Violations
 Using the buttons on the left-hand side of the map, draw a rectangle around the part of New Jersey that you want to learn more about.
 
@@ -147,3 +153,7 @@ def main():
 
 if __name__ == "__main__":
   main()
+
+next = st.button("Next: Environmental Justice")
+if next:
+    switch_page("environmental justice")

--- a/pages/3_⚖️_Environmental_Justice.py
+++ b/pages/3_⚖️_Environmental_Justice.py
@@ -4,6 +4,7 @@
 import pandas as pd
 import urllib.parse
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
 from streamlit_folium import st_folium
 import geopandas
 import folium
@@ -13,6 +14,11 @@ import json
 import requests, zipfile, io
 
 st.set_page_config(layout="wide")
+
+previous = st.button("Previous: Safe Drinking Water Act Violations")
+if previous:
+    switch_page("sdwa violations")
+
 st.markdown("""
 # How do SDWA Violations affect Environmental Justice (EJ) in this Place?
 Here you can explore socio-economic demographics and pollution exposures recorded for the place you drew a box around
@@ -173,4 +179,6 @@ def main():
 if __name__ == "__main__":
   main()
 
-
+next = st.button("Next: Lead Service Lines")
+if next:
+    switch_page("lead service lines")

--- a/pages/4_📏_Lead_Service_Lines.py
+++ b/pages/4_📏_Lead_Service_Lines.py
@@ -4,6 +4,7 @@
 import pandas as pd
 import urllib.parse
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
 from streamlit_folium import st_folium
 import geopandas
 import folium
@@ -13,6 +14,11 @@ import json
 import requests, zipfile, io
 
 st.set_page_config(layout="wide")
+
+previous = st.button("Previous: Environmental Justice")
+if previous:
+    switch_page("environmental justice")
+
 st.markdown("""
   # Lead Service Lines by Purveyor Service Area
   In New Jersey, there are some public water systems that serve
@@ -122,4 +128,6 @@ def main():
 if __name__ == "__main__":
   main()
 
-
+next = st.button("Next: Watershed Pollution")
+if next:
+    switch_page("watershed pollution")

--- a/pages/5_🌍_Watershed_Pollution.py
+++ b/pages/5_🌍_Watershed_Pollution.py
@@ -4,6 +4,7 @@
 import pandas as pd
 import urllib.parse
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
 from streamlit_folium import st_folium
 import geopandas
 import folium
@@ -13,6 +14,11 @@ import json
 import requests, zipfile, io
 
 st.set_page_config(layout="wide")
+
+previous = st.button("Previous: Lead Service Lines")
+if previous:
+    switch_page("lead service lines")
+
 st.markdown("""
   # What Pollutants are Allowed to be Released in the Watershed?
 


### PR DESCRIPTION
Ha I'm not sure what the Github-semantic way to do this is but here is the version with nice page-switch versions working:

![image](https://github.com/ericnost/streamlit_test/assets/454690/c370aec2-c424-4162-92ce-171903a1cca9)

I'm assuming it breaks in production because I added a new package (it's in the Pipfile). Is there anything special I need to do for that?