### PR TITLE
fix default map issue and enable more free-flowing navigation

### DIFF
--- a/pages/1_🌍_Statewide_Overview.py
+++ b/pages/1_🌍_Statewide_Overview.py
@@ -31,59 +31,12 @@ st.markdown("""
 st.caption("*Public water systems = water systems that serve at least 25 people, so not private wells.")
 
 def main():
-  @st.cache_data
-  def get_data(query):
-    try:
-      # Get data
-      url= 'https://portal.gss.stonybrook.edu/echoepa/?query='
-      data_location = url + urllib.parse.quote_plus(query) + '&pg'
-      data = pd.read_csv(data_location, encoding='iso-8859-1', dtype={"REGISTRY_ID": "Int64"})
-
-      # Map all SDWA PWS
-      sdwa = geopandas.GeoDataFrame(data, crs = 4269, geometry = geopandas.points_from_xy(data["FAC_LONG"], data["FAC_LAT"]))
-      # String manipulations to make output more readable
-      source_acronym_dict = {
-        'GW': 'Groundwater',
-        'SW': 'Surface water'
-        }
-      for key, value in source_acronym_dict.items():
-        sdwa['SOURCE_WATER'] = sdwa['SOURCE_WATER'].str.replace(key, value)
-      s = {"Groundwater": "3", "Surface water": "0"}
-
-      type_acronym_dict = {
-        'NTNCWS': 'Non-Transient, Non-Community Water System',
-        'TNCWS': 'Transient Non-Community Water System',
-        'CWS': 'Community Water System'
-      }
-      for key, value in type_acronym_dict.items():
-        sdwa['PWS_TYPE_CODE'] = sdwa['PWS_TYPE_CODE'].str.replace(key, value)
-      t = {'Non-Transient, Non-Community Water System': "green", 'Transient Non-Community Water System': "yellow", 'Community Water System': "blue"}
-       
-      r = {"Very Small": 2, "Small": 6, "Medium": 12, "Large": 20, "Very Large": 32}
-
-      ## Convert to circle markers
-      sdwa = sdwa.loc[sdwa["FISCAL_YEAR"] == 2021]  # for mapping purposes, delete any duplicates
-      
-      markers = [folium.CircleMarker(location=[mark.geometry.y, mark.geometry.x], 
-        popup=folium.Popup(mark["PWS_NAME"]+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+mark["SYSTEM_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]),
-        radius=r[mark["SYSTEM_SIZE"]], fill_color=t[mark["PWS_TYPE_CODE"]], dash_array=s[mark["SOURCE_WATER"]]) for index,mark in sdwa.iterrows() if not mark.geometry.is_empty]
-
-      return sdwa, markers
-    except:
-      print("Sorry, can't get data")
-
-  # Initial query (NJ PWS)
-  sql = 'select * from "SDWA_PUBLIC_WATER_SYSTEMS_MVIEW" where "STATE" = \'NJ\'' # About 3500 = 40000 records for multiple FYs #'
-  sdwa, markers = get_data(sql)
-  if "sdwa" not in st.session_state:
-    st.session_state["sdwa"] = sdwa # save for later
 
   # Streamlit section
   # Map
-  if "markers" not in st.session_state:
-    st.session_state["markers"] = []
-  if "last_active_drawing" not in st.session_state:
-    st.session_state["last_active_drawing"] = None
+  
+  #if "last_active_drawing" not in st.session_state:
+    #st.session_state["last_active_drawing"] = None
 
   c1 = st.container()
   c2 = st.container()
@@ -99,7 +52,7 @@ def main():
       m = folium.Map(location = [40.304857, -74.499739], zoom_start = 8, tiles="cartodb positron")
 
       #add markers
-      for marker in markers:
+      for marker in st.session_state["statewide_markers"]:
         m.add_child(marker)
       out = st_folium(
         m,
@@ -188,7 +141,6 @@ def main():
   st.caption("Size classifications can be found in EPA's Drinking Water Dashboard [Data Dictionary](https://echo.epa.gov/help/drinking-water-qlik-dashboard-help#dictionary)")
 
 if __name__ == "__main__":
-  with st.spinner(text="Loading data..."):
     main()
 
 next = st.button("Next: Safe Drinking Water Act Violations")

--- a/pages/2_💧_SDWA_Violations.py
+++ b/pages/2_💧_SDWA_Violations.py
@@ -56,7 +56,7 @@ with st.spinner(text="Loading data..."):
     sdwa = st.session_state["sdwa"]
     sdwa = sdwa.loc[sdwa["FISCAL_YEAR"] == 2021]  # for mapping purposes, delete any duplicates
   except:
-    st.error("### Error: Please start on the 'Statewide Overview' page.")
+    st.error("### Error: Please start on the 'Welcome' page.")
     st.stop()
 
 # Streamlit section
@@ -86,13 +86,16 @@ def main():
         edit_options={"edit": False, "remove": False}
       ).add_to(m)
 
-      if st.session_state["last_active_drawing"] is not None: # user has drawn a box
+      if (st.session_state["last_active_drawing"] is not None) and (st.session_state["data"] is not None): # else statement has already ran
+        print("IF_1")
+        # problem is that st.session_state has been assigned default box (see below) so it's just repeating that
         geo_j = folium.GeoJson(data=st.session_state["last_active_drawing"])
         geo_j.add_to(m)
       else: # default - no box drawn yet
+        print("ELSE")
         # draw box
         default_box = json.loads('{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"name": "default box"},"geometry":{"coordinates":[[[-74.28527671505785,41.002662478823],[-74.28527671505785,40.88373661477061],[-74.12408529371498,40.88373661477061],[-74.12408529371498,41.002662478823],[-74.28527671505785,41.002662478823]]],"type":"Polygon"}}]}')
-        #st.session_state["last_active_drawing"] = default_box["features"][0]
+        #st.session_state["last_active_drawing"] = default_box["features"][0]  # This will ensure default loads on other pages, but it will - at least for the first custom box drawn - override the custom box
         # add to map
         geo_j = folium.GeoJson(data=default_box)
         geo_j.add_to(m)
@@ -180,6 +183,7 @@ def main():
   if (
     (out["last_active_drawing"]) and (out["last_active_drawing"] != st.session_state["last_active_drawing"]) 
   ):
+    print("IF_2")
     bounds = out["last_active_drawing"]
     bounds = geopandas.GeoDataFrame.from_features([bounds])
     bounds.set_crs(4269, inplace=True)

--- a/pages/5_🌍_Watershed_Pollution.py
+++ b/pages/5_🌍_Watershed_Pollution.py
@@ -55,11 +55,13 @@ def get_data(query):
 with st.spinner(text="Loading data..."):
   # Get bounds of shape
   try:
-    location = geopandas.GeoDataFrame.from_features([st.session_state["last_active_drawing"]])
-    b = location.geometry.total_bounds
+    location = geopandas.GeoDataFrame.from_features([st.session_state["last_active_drawing"]]) # Try loading the active box area
+    map_data = st.session_state["last_active_drawing"]
   except:
-    st.error("### Error: Did you forget to start on the 'Statewide Overview' page and/or draw a box on the 'SDWA Violations' page?")
-    st.stop()
+    default_box = json.loads('{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"name": "default box"},"geometry":{"coordinates":[[[-74.28527671505785,41.002662478823],[-74.28527671505785,40.88373661477061],[-74.12408529371498,40.88373661477061],[-74.12408529371498,41.002662478823],[-74.28527671505785,41.002662478823]]],"type":"Polygon"}}]}')
+    location = geopandas.GeoDataFrame.from_features([default_box["features"][0]])
+    map_data = default_box["features"][0]
+    b = location.geometry.total_bounds
   # Get watershed boundary
   sql = """
   SELECT * FROM "wbdhu12" WHERE ST_INTERSECTS(ST_GeomFromText('POLYGON(({} {}, {} {}, {} {}, {} {}, {} {}))', 4269), "wbdhu12"."wkb_geometry");
@@ -147,7 +149,7 @@ def main():
       m = folium.Map(tiles = "cartodb positron")
       
       #Set watershed
-      geo_j = folium.GeoJson(st.session_state["last_active_drawing"])
+      geo_j = folium.GeoJson(map_data)
       geo_j.add_to(m)
       gj = folium.GeoJson(
         watersheds,


### PR DESCRIPTION
I believe this fixes #60 the issue where the first custom map drawn wasn't loading, but the second and others would. Now, anytime a custom map is drawn, it will load.

This also addresses #18. I believe at this point, as long as the user lands on welcome, they can navigate in any order they want and they will at least be able to get the default area (but if they don't go to Violations first they won't get markers on Lead and EJ but that could be addressed later on and it isn't vital).