### PR TITLE
responding to Marianne's feedback

### DIFF
--- a/Welcome.py
+++ b/Welcome.py
@@ -124,12 +124,12 @@ with c3:
     sdwa_circles = sdwa.loc[sdwa["FISCAL_YEAR"] == 2021]  # For mapping purposes, remove any duplicates and non-current entries
 
     markers = [folium.CircleMarker(location=[mark.geometry.y, mark.geometry.x], 
-      popup=folium.Popup(mark["PWS_NAME"]+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+mark["SYSTEM_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]),
+      popup=folium.Popup(mark["FAC_NAME"]+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+mark["SYSTEM_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]),
       radius=r[mark["SYSTEM_SIZE"]], fill_color=t[mark["PWS_TYPE_CODE"]], stroke=s[mark["SOURCE_WATER"]]) for index,mark in sdwa_circles.iterrows() if not mark.geometry.is_empty]
 
     local_sdwa_circles = sdwa_circles[sdwa_circles.geometry.intersects(bounds.geometry[0])]
     local_markers = [folium.CircleMarker(location=[mark.geometry.y, mark.geometry.x], 
-      popup=folium.Popup(mark["PWS_NAME"]+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+mark["SYSTEM_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]),
+      popup=folium.Popup(mark["FAC_NAME"]+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+mark["SYSTEM_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]),
       radius=r[mark["SYSTEM_SIZE"]], fill_color=t[mark["PWS_TYPE_CODE"]], stroke=s[mark["SOURCE_WATER"]]) for index,mark in local_sdwa_circles.iterrows() if not mark.geometry.is_empty]
 
     # Load purveyor service area (PSA) data

--- a/pages/1_🌍_Statewide_Overview.py
+++ b/pages/1_🌍_Statewide_Overview.py
@@ -59,22 +59,20 @@ def main():
           popup=folium.GeoJsonPopup(fields=['SYS_NAME', 'AGENCY_URL'], aliases=['Water system:', 'Website:'])
           ).add_to(m)
 
-        with col1:
-          out = st_folium(
-            m,
-            width = 500,
-            returned_objects=[]
-          )
+        out = st_folium(
+          m,
+          width = 500,
+          returned_objects=[]
+        )
       else:
         # Add markers representing PWS
         for marker in markers:
           m.add_child(marker)
-        with col2:
-          out = st_folium(
-            m,
-            width = 500,
-            returned_objects=[]
-          )
+        out = st_folium(
+          m,
+          width = 500,
+          returned_objects=[]
+        )
 
     with col1:
       with st.spinner(text="Loading interactive map..."):

--- a/pages/3_🚨_Drinking Water_Violations.py
+++ b/pages/3_🚨_Drinking Water_Violations.py
@@ -113,22 +113,26 @@ def main():
     # Get violations data for PWS and PSA/PWS
     violations_data = get_data_from_ids("SDWA_VIOLATIONS_MVIEW", "PWSID", these_pws)
     # Make sure that facilities with no violations still get markers
-    ## Facilities with violations
-    facs_with_violations = list(violations_data["PWSID"].unique())
-    ## Facilities without violations
-    facs_without_violations = list(set(these_pws) - set(facs_with_violations))
-    ## Add faciliities without violations information
-    facs_without_violations = sdwa[sdwa["PWSID"].isin(facs_without_violations)]
-    ## Fill in missing information from violations table
-    facs_without_violations["PWS_SIZE"] = "N/A"
-    facs_without_violations["HEALTH_BASED"] = "N" # Really should be N/A but then chart won't show correctly
-    #facs_without_violations["PWS_TYPE_CODE"] = "N/A"
-    #facs_without_violations["PWS_NAME"] = "N/A"
-    violations_data = pd.concat([violations_data, facs_without_violations])
-    # Process data, make markers, save data
-    st.session_state["violations_markers"], st.session_state["violations_colorscale"], violations_counts = marker_maker(violations_data, list(facs_without_violations["PWSID"].unique()))
-    st.session_state["violations_data"] = violations_data 
-    bounds = [[y1, x1], [y2, x2]]
+    if violations_data is not None:
+      ## Facilities with violations
+      facs_with_violations = list(violations_data["PWSID"].unique())
+      ## Facilities without violations
+      facs_without_violations = list(set(these_pws) - set(facs_with_violations))
+      ## Add faciliities without violations information
+      facs_without_violations = sdwa[sdwa["PWSID"].isin(facs_without_violations)]
+      ## Fill in missing information from violations table
+      facs_without_violations["PWS_SIZE"] = "N/A"
+      facs_without_violations["HEALTH_BASED"] = "N" # Really should be N/A but then chart won't show correctly
+      #facs_without_violations["PWS_TYPE_CODE"] = "N/A"
+      #facs_without_violations["PWS_NAME"] = "N/A"
+      violations_data = pd.concat([violations_data, facs_without_violations])
+      # Process data, make markers, save data
+      st.session_state["violations_markers"], st.session_state["violations_colorscale"], violations_counts = marker_maker(violations_data, list(facs_without_violations["PWSID"].unique()))
+      st.session_state["violations_data"] = violations_data 
+      bounds = [[y1, x1], [y2, x2]]
+    else:
+      st.error("### There are no public water systems in this area.")
+      st.stop()
 
     if st.session_state["these_psa"].empty:
       pass

--- a/pages/3_🚨_Drinking Water_Violations.py
+++ b/pages/3_🚨_Drinking Water_Violations.py
@@ -36,6 +36,7 @@ def get_data(query):
 
 # Data Processing
 def get_data_from_ids(table, key, list_of_ids):
+  print(list_of_ids)
   ids  = ""
   for i in list_of_ids:
     ids += "'"+i +"',"
@@ -46,25 +47,29 @@ def get_data_from_ids(table, key, list_of_ids):
   return data
 
 # Make the maps' markers
-def marker_maker(data):
+def marker_maker(data, facs_without_violations):
   """
   data: SDWA violations dataframe
   """
   # Process data for mapping - drop duplicates (multiple violations) to just get one marker per facility. Color marker by violation count.
-  context = data[["PWSID", "PWS_NAME", "PWS_TYPE_CODE", "PWS_SIZE", "SOURCE_WATER", "FAC_LAT", "FAC_LONG"]]
+  context = data[["PWSID", "FAC_NAME", "PWS_TYPE_CODE", "PWS_SIZE", "SOURCE_WATER", "FAC_LAT", "FAC_LONG"]]
   context.set_index("PWSID", inplace = True)
-  data = data.groupby(by=["PWSID"])[["PWSID"]].count().rename(columns={"PWSID": "COUNT"}) # Group data
+  data = data.groupby(by=["PWSID"])[["PWSID"]].count().rename(columns={"PWSID": "VIOLATIONS_COUNT"}) # Group data
   data = context.join(data).reset_index().drop_duplicates(subset=["PWSID"])
-  colorscale = branca.colormap.linear.Reds_05.scale(data["COUNT"].min(), data["COUNT"].max())
+  data.loc[data["PWSID"].isin(facs_without_violations), "VIOLATIONS_COUNT"] = 0  # Find facs_without_violations and set count to 0
+  colorscale = branca.colormap.linear.Reds_05.scale(data["VIOLATIONS_COUNT"].min(), data["VIOLATIONS_COUNT"].max())
   # Map PWS
   markers = [folium.CircleMarker(location=[mark["FAC_LAT"], mark["FAC_LONG"]], 
-    popup=folium.Popup(mark["PWS_NAME"]+'<br><b>Violations since 2001:</b> '+str(mark["COUNT"])+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+mark["PWS_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]),
+    popup=folium.Popup(mark["FAC_NAME"]+'<br><b>Violations since 2001:</b> '+
+      str(mark["VIOLATIONS_COUNT"])+'<br><b>Source:</b> '+mark["SOURCE_WATER"]+'<br><b>Size:</b> '+
+      mark["PWS_SIZE"]+'<br><b>Type:</b> '+mark["PWS_TYPE_CODE"]
+    ),
     radius=12, 
-    fill_color=colorscale(mark["COUNT"]),
+    fill_color=colorscale(mark["VIOLATIONS_COUNT"]),
     fill_opacity=1,
     weight=1,
     stroke="white") for index,mark in data.iterrows() if mark["FAC_LONG"] is not None]
-  return markers, colorscale
+  return markers, colorscale, data
 
 # Reload, but don't map, PWS
 with st.spinner(text="Loading data..."):
@@ -102,19 +107,38 @@ def main():
     # Get PWS
     these_pws = geopandas.clip(sdwa, bounds.geometry)
     these_pws = list(these_pws["PWSID"].unique())
+    # Get PSA ids
+    psa_ids = list(st.session_state["these_psa"].index.unique())
+    these_pws = these_pws + psa_ids
+    # Get violations data for PWS and PSA/PWS
     violations_data = get_data_from_ids("SDWA_VIOLATIONS_MVIEW", "PWSID", these_pws)
+    # Make sure that facilities with no violations still get markers
+    ## Facilities with violations
+    facs_with_violations = list(violations_data["PWSID"].unique())
+    ## Facilities without violations
+    facs_without_violations = list(set(these_pws) - set(facs_with_violations))
+    ## Add faciliities without violations information
+    facs_without_violations = sdwa[sdwa["PWSID"].isin(facs_without_violations)]
+    ## Fill in missing information from violations table
+    facs_without_violations["PWS_SIZE"] = "N/A"
+    facs_without_violations["HEALTH_BASED"] = "N" # Really should be N/A but then chart won't show correctly
+    #facs_without_violations["PWS_TYPE_CODE"] = "N/A"
+    #facs_without_violations["PWS_NAME"] = "N/A"
+    violations_data = pd.concat([violations_data, facs_without_violations])
     # Process data, make markers, save data
-    st.session_state["violations_markers"], st.session_state["violations_colorscale"] = marker_maker(violations_data)
+    st.session_state["violations_markers"], st.session_state["violations_colorscale"], violations_counts = marker_maker(violations_data, list(facs_without_violations["PWSID"].unique()))
     st.session_state["violations_data"] = violations_data 
     bounds = [[y1, x1], [y2, x2]]
 
     if st.session_state["these_psa"].empty:
       pass
     else:
+      # Join violations counts to these_psa
+      map_psa = st.session_state["these_psa"].merge(violations_counts, left_on="PWID", right_on="PWSID")
       folium.GeoJson(
-        st.session_state["these_psa"],
+        map_psa,
         style_function = lambda sa: {"fillOpacity": 0, "weight": 2, "color": "black"},
-        popup=folium.GeoJsonPopup(fields=['SYS_NAME', 'AGENCY_URL'])
+        popup=folium.GeoJsonPopup(fields=['SYS_NAME', 'AGENCY_URL', "VIOLATIONS_COUNT"])
       ).add_to(m)
 
     mc = FastMarkerCluster("", showCoverageOnHover = False, removeOutsideVisibleBounds = True, icon_create_function="""
@@ -155,7 +179,8 @@ def main():
     # Manipulate data
     try:
       counts = st.session_state["violations_data"].groupby(by=["FAC_NAME", "HEALTH_BASED"])[["FAC_NAME"]].count()
-      counts.rename(columns={"FAC_NAME": "COUNT"}, inplace=True)
+      counts.rename(columns={"FAC_NAME": "VIOLATIONS_COUNT"}, inplace=True)
+      counts.loc[counts.index.isin(list(facs_without_violations["FAC_NAME"].unique()),level='FAC_NAME'), "VIOLATIONS_COUNT"] = 0 # Reset facilities with no recorded violations to 0 count
       counts = counts.sort_values(by="FAC_NAME", ascending=False)
     except:
       counts = []
@@ -175,7 +200,7 @@ def main():
     #st.dataframe(counts) 
     st.altair_chart(
       alt.Chart(counts.reset_index(), title = 'Number of SDWA violations by facility, 2001-present').mark_bar().encode(
-        x = alt.X("COUNT", title = "Number of violations"),
+        x = alt.X("VIOLATIONS_COUNT", title = "Number of violations"),
         y = alt.Y('FAC_NAME', axis=alt.Axis(labelLimit = 500), title=None).sort('-x'), # Sort horizontal bar chart
         color = 'HEALTH_BASED'
       ),
@@ -186,6 +211,15 @@ def main():
       
       :face_with_monocle: Want to learn more about SDWA, all the terms that are used, and the way the law is implemented? EPA maintains an FAQ page [here](https://echo.epa.gov/help/sdwa-faqs).
     """)
+
+  # Download Data Button
+  st.download_button(
+    "Download this page's data",
+    st.session_state["violations_data"].to_csv(),
+    "selected_public_water_systems_violations.csv",
+    "text/csv",
+    key='download-csv'
+  )
 
 if __name__ == "__main__":
   main()

--- a/pages/4_⚖️_Environmental_Justice.py
+++ b/pages/4_⚖️_Environmental_Justice.py
@@ -138,7 +138,7 @@ with st.spinner(text="Loading data..."):
 if st.session_state["these_psa"].empty: # If there are no PSA to work with
   bgs = census_data[census_data.geometry.intersects(location.geometry[0])] # Block groups in the area around the clicked point
 else: # If there are PSA to work with
-  within = census_data.sindex.query(location.geometry, predicate="intersects")
+  within = census_data.sindex.query(st.session_state["these_psa"].geometry, predicate="intersects")
   bgs = census_data.iloc[within[1], :] # Block groups in the PSAs
 bg_data = bgs
 # Set bounds to drawn area
@@ -192,11 +192,14 @@ def main():
           style_function = lambda bg: {"fillColor": style(bg), "fillOpacity": .75, "weight": 1, "color": "white"},
           popup=folium.GeoJsonPopup(fields=[ejdesc], aliases=[prettier_map_labels])
         ).add_to(m)
-        psas = folium.GeoJson(
-          st.session_state["these_psa"],
-          style_function = lambda bg: {"fill": None, "weight": 2, "color": "black"},
-          tooltip=folium.GeoJsonTooltip(fields=['SYS_NAME', 'AGENCY_URL'])
-        ).add_to(m) 
+        if st.session_state["these_psa"].empty:
+          pass
+        else:
+          psas = folium.GeoJson(
+            st.session_state["these_psa"],
+            style_function = lambda bg: {"fill": None, "weight": 2, "color": "black"},
+            tooltip=folium.GeoJsonTooltip(fields=['SYS_NAME', 'AGENCY_URL'])
+          ).add_to(m) 
         mc = FastMarkerCluster("", showCoverageOnHover = False, removeOutsideVisibleBounds = True, icon_create_function="""
         function (cluster) {
           return L.divIcon({ html: "<span style='border-radius:50%; border:solid #3388ff 1px;padding:5px 10px 5px 10px; background-color:#3388ff; color:white;'>" + cluster.getChildCount() + "</span>", className: 'mycluster' });
@@ -241,11 +244,14 @@ def main():
           style_function = lambda bg: {"fillColor": style(bg), "fillOpacity": .75, "weight": 1, "color": "white"},
           popup=folium.GeoJsonPopup(fields=[envdesc], aliases=[prettier_map_labels])
         ).add_to(m)
-        psas = folium.GeoJson(
-          st.session_state["these_psa"],
-          style_function = lambda bg: {"fill": None, "weight": 2, "color": "black"},
-          tooltip=folium.GeoJsonTooltip(fields=['SYS_NAME', 'AGENCY_URL'])
-        ).add_to(m) 
+        if st.session_state["these_psa"].empty:
+          pass
+        else:
+          psas = folium.GeoJson(
+            st.session_state["these_psa"],
+            style_function = lambda bg: {"fill": None, "weight": 2, "color": "black"},
+            tooltip=folium.GeoJsonTooltip(fields=['SYS_NAME', 'AGENCY_URL'])
+          ).add_to(m) 
         mc = FastMarkerCluster("", icon_create_function="""
         function (cluster) {
           return L.divIcon({ html: "<span style='border-radius:50%; border:solid #3388ff 1px;padding:5px 10px 5px 10px; background-color:#3388ff; color:white;'>" + cluster.getChildCount() + "</span>", className: 'mycluster' });

--- a/pages/4_⚖️_Environmental_Justice.py
+++ b/pages/4_⚖️_Environmental_Justice.py
@@ -135,7 +135,11 @@ with st.spinner(text="Loading data..."):
     st.stop()
 
 # Filter to area
-bgs = census_data[census_data.geometry.intersects(location.geometry[0])] # Block groups in the area around the clicked point
+if st.session_state["these_psa"].empty: # If there are no PSA to work with
+  bgs = census_data[census_data.geometry.intersects(location.geometry[0])] # Block groups in the area around the clicked point
+else: # If there are PSA to work with
+  within = census_data.sindex.query(location.geometry, predicate="intersects")
+  bgs = census_data.iloc[within[1], :] # Block groups in the PSAs
 bg_data = bgs
 # Set bounds to drawn area
 x1,y1,x2,y2 = location.geometry.total_bounds
@@ -269,6 +273,15 @@ def main():
       
   st.caption("Source for definitions of environmental justice indicators: [socioeconomic](https://www.epa.gov/ejscreen/overview-socioeconomic-indicators-ejscreen) | [environmental](https://www.epa.gov/ejscreen/overview-environmental-indicators-ejscreen)")
   st.markdown(":arrow_right: What assumptions are built into EPA's choices and definitions of environmental justice indicators?")
+
+  # Download Data Button
+  st.download_button(
+    "Download this page's data",
+    bg_data.to_csv(),
+    "selected_area_ej_measures.csv",
+    "text/csv",
+    key='download-csv'
+  )
 
 if __name__ == "__main__":
   main()

--- a/pages/4_⚖️_Environmental_Justice.py
+++ b/pages/4_⚖️_Environmental_Justice.py
@@ -56,7 +56,7 @@ def add_spatial_data(url, name, projection=4326):
   ----------
   url: a zip of shapefile (in the future, extend to geojson)
   name: a string handle for the data files
-  projection (optional): an EPSG projection for the spatial dataa
+  projection (optional): an EPSG projection for the spatial data
 
   Returns
   -------
@@ -139,7 +139,8 @@ if st.session_state["these_psa"].empty: # If there are no PSA to work with
   bgs = census_data[census_data.geometry.intersects(location.geometry[0])] # Block groups in the area around the clicked point
 else: # If there are PSA to work with
   within = census_data.sindex.query(st.session_state["these_psa"].geometry, predicate="intersects")
-  bgs = census_data.iloc[within[1], :] # Block groups in the PSAs
+  bgs = census_data.iloc[list(set(within[1]))] # Block groups in the PSAs
+
 bg_data = bgs
 # Set bounds to drawn area
 x1,y1,x2,y2 = location.geometry.total_bounds

--- a/pages/5_📏_Lead_Service_Lines.py
+++ b/pages/5_📏_Lead_Service_Lines.py
@@ -81,7 +81,7 @@ def main():
 
   with c1:
     st.markdown("""
-      # Map of Purveyor Service Areas in Selected Area
+      ## Map of Purveyor Service Areas in Selected Area
       
       According to the [New Jersey Department of Environmental Protection](https://geo.btaa.org/catalog/00e7ff046ddb4302abe7b49b2ddee07e_13),
 
@@ -174,6 +174,16 @@ def main():
               
       :arrow_right: In some selected areas, you may see that some Public Water Systems report "0" and others fail to report ("None" in the table). These are not the same! "None" means that the report is missing. We don't know how many lead service lines there are in that area. Notice that these water systems are missing from the graph. What might be a good way to visualize this missing data?
     """)
+
+  # Download Data Button
+  st.download_button(
+    "Download this page's data",
+    lead_data.to_csv(),
+    "selected_area_leadlines.csv",
+    "text/csv",
+    key='download-csv'
+  )
+
 if __name__ == "__main__":
   main()
 

--- a/pages/5_📏_Lead_Service_Lines.py
+++ b/pages/5_📏_Lead_Service_Lines.py
@@ -79,6 +79,11 @@ def main():
   c1 = st.container()
   c2 = st.container()
 
+  if lead_data.empty:
+    with c1:
+      st.error("### There are no purveyor service areas required to count lead service lines in this area.")
+      st.stop()
+
   with c1:
     st.markdown("""
       ## Map of Purveyor Service Areas in Selected Area
@@ -102,16 +107,11 @@ def main():
           return "#d3d3d3" if feature["properties"]["Number of lead service lines in area"] is None else colorscale(feature["properties"]["Number of lead service lines in area"])
 
         # Add PSA service areas
-        if lead_data.empty:
-          with col1:
-            st.error("### There are no purveyor service areas required to count lead service lines in this area.")
-            st.stop()
-        else:
-          gj = folium.GeoJson(
-            lead,
-            style_function = lambda sa: {"fillColor": style(sa), "fillOpacity": .75, "weight": 2, "color": "black"},
-            popup=folium.GeoJsonPopup(fields=['Utility', "Number of lead service lines in area", "System Size"])
-            ).add_to(m)
+        gj = folium.GeoJson(
+          lead,
+          style_function = lambda sa: {"fillColor": style(sa), "fillOpacity": .75, "weight": 2, "color": "black"},
+          popup=folium.GeoJsonPopup(fields=['Utility', "Number of lead service lines in area", "System Size"])
+          ).add_to(m)
 
         out = st_folium(
           m,

--- a/pages/5_📏_Lead_Service_Lines.py
+++ b/pages/5_📏_Lead_Service_Lines.py
@@ -102,11 +102,16 @@ def main():
           return "#d3d3d3" if feature["properties"]["Number of lead service lines in area"] is None else colorscale(feature["properties"]["Number of lead service lines in area"])
 
         # Add PSA service areas
-        gj = folium.GeoJson(
-          lead,
-          style_function = lambda sa: {"fillColor": style(sa), "fillOpacity": .75, "weight": 2, "color": "black"},
-          popup=folium.GeoJsonPopup(fields=['Utility', "Number of lead service lines in area", "System Size"])
-          ).add_to(m)
+        if lead_data.empty:
+          with col1:
+            st.error("### There are no purveyor service areas required to count lead service lines in this area.")
+            st.stop()
+        else:
+          gj = folium.GeoJson(
+            lead,
+            style_function = lambda sa: {"fillColor": style(sa), "fillOpacity": .75, "weight": 2, "color": "black"},
+            popup=folium.GeoJsonPopup(fields=['Utility', "Number of lead service lines in area", "System Size"])
+            ).add_to(m)
 
         out = st_folium(
           m,

--- a/pages/6_🐟_Watershed_Pollution.py
+++ b/pages/6_🐟_Watershed_Pollution.py
@@ -209,5 +209,13 @@ def main():
 
   st.markdown(":arrow_right: What is the impact of these different pollutants? What are the possible impacts at different amounts in drinking water? You can learn more about some pollutants in EPA's [IRIS (Integrated Risk Information System) database](https://iris.epa.gov/AtoZ/?list_type=alpha).")
 
+  # Download Data Button
+  st.download_button(
+    "Download this page's data",
+    dmr.to_csv(),
+    "selected_area_pollutants.csv",
+    "text/csv",
+    key='download-csv'
+  )
 if __name__ == "__main__":
   main()

--- a/pages/6_🐟_Watershed_Pollution.py
+++ b/pages/6_🐟_Watershed_Pollution.py
@@ -59,6 +59,10 @@ with st.spinner(text="Loading data..."):
     st.error("### Error: Please start on the 'Welcome' page.")
     st.stop()
   # Set bounds
+  if st.session_state["these_psa"].empty: # If there are no PSA to work with
+    location = location
+  else: # If there are PSA to work with
+    location = st.session_state["these_psa"]
   b = location.geometry.total_bounds
   x1,y1,x2,y2 = location.geometry.total_bounds
   bounds = [[y1, x1], [y2, x2]]
@@ -155,7 +159,10 @@ def main():
           watersheds,
           style_function = lambda sa: {"fillColor": "#C1E2DB", "fillOpacity": .75, "weight": 1, "color": "white"}
           ).add_to(m)
-        psas = folium.GeoJson(
+        if st.session_state["these_psa"].empty:
+          pass
+        else:
+          psas = folium.GeoJson(
             st.session_state["these_psa"],
             style_function = lambda bg: {"fill": None, "weight": 2, "color": "black"},
             tooltip=folium.GeoJsonTooltip(fields=['SYS_NAME', 'AGENCY_URL'])


### PR DESCRIPTION
fixes #123 
fixes #128 
fixes #129 
fixes #132 (I think)

These edits do a few things:
- allow downloading the most important data on each page (except welcome and statewide overview)
- changes some styling on "Find" to ensure that facility markers are visible against the blue-filled polygons whose styling we can't change at the moment. For instance, this yellow is now more opaque and hence visible:
<img width="181" alt="image" src="https://github.com/ericnost/streamlit_test/assets/6888951/f12d9606-1fe6-48de-8521-25ac811514e7">

- on "Find", loads ALL PWS that have something to do with the map bounds. Any PSA that intersects with the map bounds will also see its PWS equivalent loaded, ensuring that the charts at the bottom of the page are accurate
- on "Violations", likewise loads ALL PWS that have something to do with the map bounds, ensuring all facilities have violations displayed. Counts are added to the PSA popups.

<img width="332" alt="image" src="https://github.com/ericnost/streamlit_test/assets/6888951/0cdd67bf-f0fc-459d-81f4-d1ead55e5d73">

- also on "Violations", deals with facilities that have NO recorded violations. Previously, these were dropped, leading to a misleading and perhaps confusing state where facilities would disappear from the map between "Find" and "Violations". 

<img width="81" alt="image" src="https://github.com/ericnost/streamlit_test/assets/6888951/cfbe1599-4962-4f8d-b231-4f8ae0ccdd73">

<img width="331" alt="image" src="https://github.com/ericnost/streamlit_test/assets/6888951/f541aeeb-5651-4c77-88f4-6f4a6210c835">

- on "EJ", gets all block groups that intersect with any PSA that intersects with the map bounds, kind of getting towards Marianne's request to summarize EJ data by PSA

<img width="485" alt="image" src="https://github.com/ericnost/streamlit_test/assets/6888951/686037b8-05a8-4613-b211-6992f68d5b8b">

- does the same on "Watersheds"

<img width="405" alt="image" src="https://github.com/ericnost/streamlit_test/assets/6888951/ccbc3834-9ac5-4032-95c4-fcc06ab007df">

- the above two changes could get unwieldy but we can always change back or limit the zoom in order to limit the data load
